### PR TITLE
Add o to the list of free particles

### DIFF
--- a/data.go
+++ b/data.go
@@ -7,6 +7,7 @@ var particles = map[string]struct{}{
 	"li": {},
 	"e":  {},
 	"la": {},
+	"o": {},
 	"pi": {},
 }
 


### PR DESCRIPTION
Add's o to the list of particles which players can freely insert into phrases.


As a fairly frequent player of the game(ma pona la mi ala Kelikun), I think o doesn't come up often enough in the right places to make phrases which use o viable, which is a shame because I think o sentences are great for musi Ako, because telling people to do stuff is fun. 