### PR TITLE
Fix consecutive-letter bug; improve punctuation stripper

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -80,7 +80,7 @@ func votePhase(c *gateway.MessageCreateEvent) {
 	}
 
 	if c.Author.ID == id {
-		bot.SendMessage(c.ChannelID, fmt.Sprintf("ike a · <@%d> li pali ike ·", c.Author.ID), nil)
+		bot.SendMessage(c.ChannelID, fmt.Sprintf("<@%d> o : jan li ken ala pana e wile ona tawa toki pi ona kin ·", c.Author.ID), nil)
 		bot.DeleteMessage(c.ChannelID, c.ID)
 		return
 	}
@@ -128,7 +128,7 @@ func strip (s string) string {
     for _, mu := range s { // mu ali la
         if unicode.IsLetter(mu) || unicode.IsNumber(mu) {
             if weka {
-                ns += ' ' // ken la " " li pona
+                ns += " " // ken la ' ' kin li pona
                 weka = false
             }
             ns += string(mu)
@@ -285,7 +285,7 @@ func dataPhase(c *gateway.MessageCreateEvent) {
 	}
 
 	if dataStates[c.ChannelID].searchAlreadyHas(fields) {
-		bot.SendMessage(c.ChannelID, fmt.Sprintf("<@%d> o, jan ante li kepeken toki sina. o toki ante!", c.Author.ID), nil)
+		bot.SendMessage(c.ChannelID, fmt.Sprintf("<@%d> o : toki sina li sama toki pi jan ante · o toki ante ·", c.Author.ID), nil)
 		bot.DeleteMessage(c.ChannelID, c.ID)
 		return
 	}
@@ -317,13 +317,13 @@ func leaderboard(c *gateway.MessageCreateEvent) {
 	sb := []string{}
 
 	for _, user := range users {
-		sb = append(sb, fmt.Sprintf("<@%d> - tenpo %d", user.DiscordID, user.WonGames))
+		sb = append(sb, fmt.Sprintf("**%d** · <@%d>", user.WonGames, user.DiscordID))
 	}
 
 	bot.SendMessage(
 		c.ChannelID, "",
 		pona(
-			"jan mute li wile e toki pi jan ni:",
+			"jan mute la jan ni li suli :",
 			strings.Join(sb, "\n"),
 		),
 	)
@@ -361,11 +361,11 @@ func startGame(c *gateway.MessageCreateEvent) {
 	}
 
 	if _, ok := gameStates[c.ChannelID]; ok {
-		bot.SendMessage(c.ChannelID, "musi li lon. o musi kepeken ona!", nil)
+		bot.SendMessage(c.ChannelID, "tomo ni la musi li lon a · o musi lon ona ·", nil)
 		return
 	}
 
-	bot.SendMessage(c.ChannelID, "", pona(fmt.Sprintf("o pana e toki kepeken open ni: `%s`", strings.Join(data, " ")), ""))
+	bot.SendMessage(c.ChannelID, "", pona(fmt.Sprintf("`%s`", strings.Join(data, " ")), "kepeken mu open ni la o pana e toki ·"))
 
 	gameStates[c.ChannelID] = sending
 	dataStates[c.ChannelID] = sendData{
@@ -376,14 +376,14 @@ func startGame(c *gateway.MessageCreateEvent) {
 	go func() {
 		go func() {
 			time.Sleep(time.Duration(0.8*duration) * time.Second)
-			bot.SendMessage(c.ChannelID, "tenpo li weka!", nil)
+			bot.SendMessage(c.ChannelID, "tenpo li lon poka weka ·", nil)
 		}()
 
 		time.Sleep(time.Duration(duration) * time.Second)
 		gameStates[c.ChannelID] = voting
 
 		if len(dataStates[c.ChannelID].phrases) == 0 {
-			bot.SendMessage(c.ChannelID, "", ike("jan ala li pana e toki ona! ike a...", ""))
+			bot.SendMessage(c.ChannelID, "", ike("ike la jan ala li pana e toki ona ·", ""))
 			delete(gameStates, c.ChannelID)
 
 			return
@@ -404,12 +404,12 @@ func startGame(c *gateway.MessageCreateEvent) {
 			voteStates[c.ChannelID].keys[i] = member
 		}
 
-		bot.SendMessage(c.ChannelID, "", pona("tenpo li pini a! o toki e wile sina tan ni:", s.String()))
+		bot.SendMessage(c.ChannelID, "", pona("tenpo li pini · o pana e wile sina tan toki ni :", s.String()))
 
 		go func() {
 			go func() {
 				time.Sleep(time.Duration(0.8*duration) * time.Second)
-				bot.SendMessage(c.ChannelID, "tenpo li weka!", nil)
+				bot.SendMessage(c.ChannelID, "tenpo li lon poka weka ·", nil)
 			}()
 
 			time.Sleep(time.Duration(duration) * time.Second)
@@ -441,9 +441,9 @@ func startGame(c *gateway.MessageCreateEvent) {
 
 			if winner == 0 {
 				if couldVotes <= votes {
-					bot.SendMessage(c.ChannelID, "", ike("jan ala li toki e wile ona. ike a...", ""))
+					bot.SendMessage(c.ChannelID, "", ike("ike la jan ala li pana e wile ona ·", ""))
 				} else {
-					bot.SendMessage(c.ChannelID, "", meso("", fmt.Sprintf("tenpo ante la <@%d> li ken pona, taso ona li toki ala e wile ona. jan li toki ala e wile tawa jan ante.", couldWinner)))
+					bot.SendMessage(c.ChannelID, "", meso("", fmt.Sprintf("tenpo ante la <@%d> li ken pona · taso ona li toki ala e wile ona tawa jan ante ·", couldWinner)))
 				}
 				delete(gameStates, c.ChannelID)
 
@@ -464,9 +464,9 @@ func startGame(c *gateway.MessageCreateEvent) {
 			count := user.Update().AddWonGames(1).SaveX(ctx).WonGames
 
 			if couldVotes <= votes {
-				bot.SendMessage(c.ChannelID, "", pona("", fmt.Sprintf("jan mute li wile toki pi <@%d>!\nona li toki e ni: %s.\nni li tenpo nanpa %d tawa ona.", winner, strings.Join(phraseData.phrases[winner], " "), count)))
+				bot.SendMessage(c.ChannelID, "", pona("", fmt.Sprintf("jan mute li wile e toki pi <@%d> ·\nona li toki e ni : %s\nni li tenpo nanpa %d tawa ona ·", winner, strings.Join(phraseData.phrases[winner], " "), count)))
 			} else {
-				bot.SendMessage(c.ChannelID, "", pona("", fmt.Sprintf("jan mute li wile toki pi <@%d>!\nona li toki e ni: %s.\nni li tenpo nanpa %d tawa ona.\ntenpo ante la <@%d> li ken pona, taso ona li toki ala e wile ona.", winner, strings.Join(phraseData.phrases[winner], " "), count, couldWinner)))
+				bot.SendMessage(c.ChannelID, "", pona("", fmt.Sprintf("jan mute li wile e toki pi <@%d> ·\nona li toki e ni : %s\nni li tenpo nanpa %d tawa ona ·\ntenpo ante la <@%d> li ken pona · taso ona li pana ala e wile ona ·", winner, strings.Join(phraseData.phrases[winner], " "), count, couldWinner)))
 			}
 		}()
 	}()

--- a/commands.go
+++ b/commands.go
@@ -179,6 +179,11 @@ func statedWordsFromSentence(s []string) []statedWord {
     return sw
 }
 
+func isPart(s string) bool {
+	_, ok := particles[s]
+	return ok
+}
+
 // s = every word in the input accompanied by a ala-ken-lon state
 // l = array of original letters, e.g. {"a", "k", "o"}
 func checksOut(s []statedWord, l []string) bool {
@@ -332,7 +337,7 @@ func leaderboard(c *gateway.MessageCreateEvent) {
 	bot.SendMessage(
 		c.ChannelID, "",
 		pona(
-			"jan mute la jan ni li suli :",
+			"jan li pona lon tenpo pi mute ni :",
 			strings.Join(sb, "\n"),
 		),
 	)
@@ -353,21 +358,17 @@ func startGame(c *gateway.MessageCreateEvent) {
 	var data []string
 
 	duration := float64(dur)
-	if strings.Contains(c.Content, "tenpo mute") {
-		duration = dur * 1.5
+	if strings.Contains(c.Content, "sin wan") {
+		data = randomLetters(1)
+	} else if strings.Contains(c.Content, "sin tu") {
 		data = randomLetters(2)
-	} else if strings.Contains(c.Content, "tenpo lili") {
-		duration = dur * 0.5
-		data = randomLetters(-1)
-	} else if strings.Contains(c.Content, "tenpo pi lili mute") {
-		duration = dur * 0.2
-		data = randomLetters(-2)
-	} else if strings.Contains(c.Content, "tenpo ale") {
-		duration = 300
-		data = randomLetters(12)
+	} else if strings.Contains(c.Content, "sin mute") {
+		data = randomLetters(3)
 	} else {
 		data = randomLetters(0)
 	}
+    
+    duration = len(data) * 15 // 15 seconds per letter
 
 	if _, ok := gameStates[c.ChannelID]; ok {
 		bot.SendMessage(c.ChannelID, "tomo ni la musi li lon a · o musi lon ona ·", nil)

--- a/commands.go
+++ b/commands.go
@@ -144,6 +144,15 @@ func strip (s string) string {
     return ns[1:] // with first space removed (is always a space)
 }
 
+var particles = map[string]struct{}{
+	"la": {},
+	"li": {},
+	"o" : {},
+	"en": {},
+	"e" : {},
+	"pi": {},
+}
+
 type validationState int
 
 const (

--- a/data.go
+++ b/data.go
@@ -1,33 +1,83 @@
 package main
 
 import "math/rand"
+// import "fmt"   // for testing
+// import "time"
 
-var letterData = []string{"k", "l", "m", "n", "p", "s", "t", "w", "j", "a", "e", "i", "o", "u", "k", "l", "m", "n", "p", "s", "t", "w", "j", "a", "e", "i", "o", "u", "k", "l", "m", "n", "p", "s", "t", "w", "j", "a", "e", "i", "o", "u"}
-var particles = map[string]struct{}{
+var particles = map[string]struct{} {
 	"li": {},
 	"e":  {},
 	"la": {},
 	"o":  {},
 	"pi": {},
-	"a":  {},
+	"en": {},
 }
 
-func randomLetter() string {
-	return letterData[rand.Intn(len(letterData))]
+// kiwen — lon musi la sitelen ‹.› li kama weka
+
+const nPoka int = 12 // nanpa poka kiwen
+
+var kiwenSuli = [5]string {
+    "eioujklmnpst",
+    "aiojklmnpstw",
+    "alnpst......",
+    "akmpsw......",
+    "klmntw......",
 }
 
-func randomLength() int {
-	return rand.Intn(3) + 2
+var kiwenNamako = [5]string {
+    "aouwljptknms",
+    "aeiwljptknms",
+    "aiouwlptknms",
+    "aiowljptknms",
+    "aeowljptknms",
 }
 
-func randomLetters(tip int) []string {
-	length := randomLength() + tip
-	if length < 2 {
-		length = 2
-	}
-	arr := make([]string, length)
-	for i := 0; i < length; i++ {
-		arr[i] = randomLetter()
-	}
-	return arr
+func randomLetters(nNamako int) []string {
+    // theoretical maximum number of letters
+    nMuSewi := len(kiwenSuli) + nNamako * len(kiwenNamako)
+    
+    // empty array with capacity set at maximum theoretical
+    mu := make([]string, 0, nMuSewi)
+
+    /// o kama jo e mu tan kiwen suli
+    for k := 0; k < len(kiwenSuli); k++ { // k = kiwen
+        rand.Seed(time.Now().UTC().UnixNano())
+        m := string(kiwenSuli[k][rand.Intn(nPoka)]) // roll one die
+        if m != "." { // if not ‹.›: add;
+            mu = append(mu, m)
+        }             // if ‹.›: continue
+    }
+    
+    /// o kama jo e mu tan kiwen namako
+    for t := 0; t < nNamako; t++ { // t = tenpo
+        for k := 0; k < len(kiwenNamako); k++ { // k = kiwen
+            m := string(kiwenNamako[k][rand.Intn(nPoka)]) // roll one die
+            if m != "." { // if not ‹.›: add;
+                mu = append(mu, m)
+            }             // if ‹.›: continue
+        }
+    }
+    
+    /// o nasa e mu
+    nMu := len(mu) // the actual number of letters it has
+    nasinNasa := rand.Perm(nMu) // random shuffle order
+    
+    muNasa := make([]string, nMu)
+    
+    // construct new array by using the random permutation
+    for m := 0; m < nMu; m++ { // m = mu
+        muNasa[m] = mu[nasinNasa[m]]
+    }
+    
+	return muNasa
 }
+
+/* // for testing
+func main() {
+    for j := 0; j < 10; j++ {
+        fmt.Println(randomLetters(0))
+        // o ante e nanpa pi kulupu pi kiwen namako
+    }
+}
+// */

--- a/data.go
+++ b/data.go
@@ -42,7 +42,7 @@ func randomLetters(nNamako int) []string {
 
     /// o kama jo e mu tan kiwen suli
     for k := 0; k < len(kiwenSuli); k++ { // k = kiwen
-        rand.Seed(time.Now().UTC().UnixNano())
+        // rand.Seed(time.Now().UTC().UnixNano()) // will be done in commands.go, although here is probably better
         m := string(kiwenSuli[k][rand.Intn(nPoka)]) // roll one die
         if m != "." { // if not ‹.›: add;
             mu = append(mu, m)

--- a/data.go
+++ b/data.go
@@ -2,16 +2,7 @@ package main
 
 import "math/rand"
 // import "fmt"   // for testing
-// import "time"
-
-var particles = map[string]struct{} {
-	"li": {},
-	"e":  {},
-	"la": {},
-	"o":  {},
-	"pi": {},
-	"en": {},
-}
+// import "time"  //
 
 // kiwen — lon musi la sitelen ‹.› li kama weka
 


### PR DESCRIPTION
I hope this works properly.
To be solved in the future:
1. searchAlreadyHas is a linear-time operation. With a proper hash map, it could run in constant time
2. fields (defined before the empty braille function) could be replaced by the s (defined before the !checksOut check). In that case, sendData must store strings instead of lists of strings.

Some things have now become unused. I tried to delete them, but it could be that I have overlooked some, which means Go will throw an error.